### PR TITLE
fix indentation

### DIFF
--- a/pyarchey/pyarchey.py
+++ b/pyarchey/pyarchey.py
@@ -284,10 +284,10 @@ elif dist == 'freebsd':
     dist = 'FreeBSD'
 else:
     try:
-    	dist = Popen(['lsb_release', '-is'], stdout=PIPE).communicate()[0].decode('Utf-8').rstrip('\n')
+        dist = Popen(['lsb_release', '-is'], stdout=PIPE).communicate()[0].decode('Utf-8').rstrip('\n')
     except:
-    	#print 'Error w/ lsb_release'
-    	ans,dist = fileCheck('/etc/os-release')
+        #print 'Error w/ lsb_release'
+        ans,dist = fileCheck('/etc/os-release')
         if not ans: dist = 'Debian'
 
 def autoSize(used,total):


### PR DESCRIPTION
I was getting a 'TabError: inconsistent use of tabs and spaces in indentation' when I tried to run pyarchey on Arch with python3.  This just fixes the indentation so that it will run.
