### PR TITLE
fix 'inconsistent use of tabs and spaces in indentation' for python3

### DIFF
--- a/pyarchey/pyarchey.py
+++ b/pyarchey/pyarchey.py
@@ -379,10 +379,10 @@ class Output:
         return ans,dist
 
     def detectDistro(self):
-    	"""
-    	Attempts to determine the distribution and draw the logo. However, if it can't, 
-    	then it defaults to 'Linux' and draws a simple linux penguin. 
-    	"""
+        """
+        Attempts to determine the distribution and draw the logo. However, if it can't, 
+        then it defaults to 'Linux' and draws a simple linux penguin. 
+        """
         dist = _platform
         if dist == 'darwin':
             dist = 'Mac OSX'


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/pyarchey", line 7, in <module>
    from pyarchey.pyarcher import main
  File "/usr/lib/python3.4/site-packages/pyarchey/pyarchey.py", line 386
    dist = _platform
                   ^

TabError: inconsistent use of tabs and spaces in indentation
```

According to [PEP8 Tabs or Spaces?](https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces)

> Python 3 disallows mixing the use of tabs and spaces for indentation.
